### PR TITLE
Prerequisite for sending events from widget to google analytics

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,7 @@ import { donationReducer } from "./store/donation/reducer";
 import { layoutReducer } from "./store/layout/reducer";
 import { errorReducer } from "./store/error/reducer";
 import { Host } from "./components/Host";
-import watchAll from "./store/root.saga";
+import { watchAll, postMessageMiddleware } from "./store/root.saga";
 import { referralReducer } from "./store/referrals/reducer";
 
 const rootReducer = combineReducers<State>({
@@ -26,7 +26,7 @@ const rootReducer = combineReducers<State>({
 const sagaMiddleware = createSagaMiddleware();
 const store = createStore(
   rootReducer,
-  composeWithDevTools(applyMiddleware(sagaMiddleware))
+  composeWithDevTools(applyMiddleware(sagaMiddleware, postMessageMiddleware))
 );
 sagaMiddleware.run(watchAll);
 

--- a/src/store/root.saga.ts
+++ b/src/store/root.saga.ts
@@ -1,3 +1,4 @@
+import { Middleware } from "redux";
 import { all, takeLatest } from "redux-saga/effects";
 import {
   draftAgreementAction,
@@ -19,8 +20,25 @@ import {
 } from "./referrals/actions";
 import { fetchReferrals, submitReferral } from "./referrals/saga";
 
+export const postMessageMiddleware: Middleware = ({ getState }) => (next) => (
+  action
+) => {
+  if (action.type === "REGISTER_DONATION_DONE") {
+    const { donation } = getState();
+    const eventData = {
+      action: "Donation registered",
+      category: "Donation",
+      label: donation.recurring,
+      value: donation.sum,
+    };
+    window.parent.postMessage(eventData, "https://gieffektivt.no/");
+  }
+
+  return next(action);
+};
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-function* watchAll() {
+export function* watchAll() {
   yield all([
     takeLatest(fetchOrganizationsAction.started.type, fetchOrganizations),
     takeLatest(fetchReferralsAction.started.type, fetchReferrals),
@@ -31,5 +49,3 @@ function* watchAll() {
     takeLatest(draftAvtaleGiroAction.started.type, draftAvtaleGiro),
   ]);
 }
-
-export default watchAll;

--- a/src/store/root.saga.ts
+++ b/src/store/root.saga.ts
@@ -1,5 +1,6 @@
 import { Middleware } from "redux";
 import { all, takeLatest } from "redux-saga/effects";
+import { RecurringDonation } from "../types/Enums";
 import {
   draftAgreementAction,
   draftAvtaleGiroAction,
@@ -28,7 +29,10 @@ export const postMessageMiddleware: Middleware = ({ getState }) => (next) => (
     const eventData = {
       action: "Donation registered",
       category: "Donation",
-      label: donation.recurring,
+      label:
+        donation.recurring === RecurringDonation.RECURRING
+          ? "Recurring"
+          : "Non-recurring",
       value: donation.sum,
     };
     window.parent.postMessage(eventData, "https://gieffektivt.no/");


### PR DESCRIPTION
Code for posting event data to the widget's parent so that google analytics events can be registered for stuff happening inside the iframe.

Todo:
- [x] Add gtag script-tag in tilda's html head
- [x] Add onmessage snippet after iframe code in tilda
`<script>
  window.onmessage = function (e) {
    if (event.origin !== 'https://storage.googleapis.com') {
      return
    }
    if (event.data && event.data.action) {
      var data = event.data
      gtag('event', data.action, {
        event_category: data.category,
        event_label: data.label,
        value: data.value,
      })
    }
  }
</script>`

❔ Question: How do you keep dev/stage in sync with master? Okay if I merge master to dev to get the latest changes?